### PR TITLE
PMT-682 Look for toggl project by exact match

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,4 +2,4 @@ mock==2.0.0
 pytest==3.1.3
 WebTest==2.0.27
 freezegun==0.3.9
-PyYAML==3.12  # Required for CI and CD config scripts
+pyyaml>=4.2b1 # Required for CI and CD config scripts

--- a/stanwood/external_services/toggl/toggl.py
+++ b/stanwood/external_services/toggl/toggl.py
@@ -144,8 +144,11 @@ class Toggl(object):
 
     def get_project_by_prefix(self, project_name_prefix):
         projects = self._fetch(self.API_URL + '/workspaces/{}/projects'.format(self.workspace))
+        projects_exact_match = filter(lambda project: project['name'] == project_name_prefix, projects)
+        projects_starting_with = filter(lambda project: project['name'].startswith(project_name_prefix + ' '), projects)
+
         try:
-            return filter(lambda project: project['name'].startswith(project_name_prefix+' '), projects)[0]
+            return (projects_exact_match + projects_starting_with)[0]
         except IndexError:
             raise TogglNotFoundError('No project name starts with {}'.format(project_name_prefix))
 


### PR DESCRIPTION
This way we are allowing to enable auto tracker for projects which exist
in Toggl but do not exist in Jira.